### PR TITLE
20160426: abstract css/constants out of head include

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -1,0 +1,15 @@
+<?php
+
+	// ******************
+	// site constants
+	// doesn't need connection to DB
+	// ******************
+
+	// let's show errors!
+	if ( isset( $_GET[ "show_errors" ] ) ) {
+		ini_set( "display_errors", 1 );
+		ini_set( "display_startup_errors", 1 );
+		error_reporting( E_ALL );
+	}
+
+?>

--- a/includes/css.php
+++ b/includes/css.php
@@ -1,0 +1,9 @@
+<?php
+	// create a link prefix if necessary
+	$link_prefix = $is_this_admin ? "../" : "";
+?>
+
+<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet" type="text/css">
+
+<link href="<?php echo $link_prefix; ?>css/reset.css" rel="stylesheet" type="text/css">
+<link href="<?php echo $link_prefix; ?>css/simhoop.css" rel="stylesheet" type="text/css">

--- a/includes/head.php
+++ b/includes/head.php
@@ -1,12 +1,9 @@
 <?php
 
+	include "includes/constants.php";
 	include "includes/connect.php";
 	include "class/player_class.php";
 	include "class/team_class.php";
+	include "includes/css.php";
 
 ?>
-
-<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet" type="text/css">
-
-<link href="css/reset.css" rel="stylesheet" type="text/css">
-<link href="css/simhoop.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
- Removed some of the stuff that was in head to separate includes (constants, css)
- Added ?show_errors functionality to display PHP errors